### PR TITLE
Add support for unencrypted http URLs

### DIFF
--- a/src/main/java/edu/washington/shibboleth/attribute/resolver/dc/rws/HttpDataSource.java
+++ b/src/main/java/edu/washington/shibboleth/attribute/resolver/dc/rws/HttpDataSource.java
@@ -73,6 +73,7 @@ import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.params.BasicHttpParams;
 
 import org.apache.http.conn.socket.ConnectionSocketFactory;
+import org.apache.http.conn.socket.PlainConnectionSocketFactory;
 
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.conn.ClientConnectionManager;
@@ -143,7 +144,10 @@ public class HttpDataSource {
        log.info("HttpDataSource: initialize");
        
        SSLConnectionSocketFactory sf = getSocketFactory();
-       Registry<ConnectionSocketFactory> socketFactoryRegistry = RegistryBuilder.<ConnectionSocketFactory> create().register("https", sf).build();
+       Registry<ConnectionSocketFactory> socketFactoryRegistry = RegistryBuilder.<ConnectionSocketFactory> create()
+         .register("https", sf)
+         .register("http", PlainConnectionSocketFactory.INSTANCE)
+         .build();
 
        connectionManager = new PoolingHttpClientConnectionManager(socketFactoryRegistry);
        connectionManager.setMaxTotal(maxConnections);


### PR DESCRIPTION
@jimfox I decided to take a crack at this.  I tested this on my IdP and it appears to work.  

Regarding the bigger picture on the security side of this, I suppose if you wanted to lock down plain HTTP a little more, it could be only added on the condition that `authenticationType=NONE`, but I think that's a little more work than my expertise is worthy of.  ;-)

Thank you!